### PR TITLE
fix(gamification): Module 4 unlock requirement was too high

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -180,7 +180,7 @@ export const MODULES: Module[] = [
     title: 'Testing + App Store Preparation',
     description: 'Preparar y publicar en las tiendas de apps',
     icon: '🏪',
-    requiredXP: 600,
+    requiredXP: 450,
     lessons: [
       'testing-strategy',
       'play-store',


### PR DESCRIPTION
## Summary
Fixed XP requirement for Module 4 being unreachable for most users.

### Problem
- Module 4 required 600 XP to unlock
- Completing Modules 1-3 with passing (70%+) quiz scores yields only 535 XP
- Only users achieving perfect scores on ALL quizzes could reach 610 XP

### Solution
Lowered Module 4 requirement from 600 XP to 450 XP, which is achievable with standard progression.

## Test plan
- [x] All 463 tests pass
- [x] Users completing M1-M3 with passing quizzes (535 XP) can now unlock M4

🤖 Generated with [Claude Code](https://claude.com/claude-code)