### PR TITLE
docs: update documentation for Module 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,39 +4,61 @@
 
 Plataforma educativa gamificada para aprender **Ionic + Capacitor**. SPA con React + TypeScript que incluye cursos, quizzes y mini-juegos.
 
+**Live:** https://capacitor-learning-platform.vercel.app
+
 ## Stack
 
 | Tech | Version/Tool |
 |------|--------------|
 | React | 18+ |
 | TypeScript | strict mode |
-| Build | Vite |
+| Build | Vite 5 |
 | Styling | Tailwind CSS |
 | Routing | React Router v6 |
 | State | React hooks + Context |
 | Storage | localStorage |
-| Testing | Jest + RTL |
+| Testing | Vitest + RTL |
 | Animations | Framer Motion |
 | Icons | Lucide React |
+| i18n | react-i18next (ES/EN/PT) |
 
 ## Estructura
 
 ```
 src/
 ├── components/
-│   ├── common/        # Button, Card, Modal, Toast
-│   ├── layout/        # Navbar, Sidebar, Footer
+│   ├── common/        # Button, Card, Modal, Toast, Icon, LanguageSwitcher
+│   ├── layout/        # Navbar, Sidebar, Footer, Layout
 │   ├── dashboard/     # ModuleCard, StatsPanel, BadgeGrid
 │   ├── lesson/        # LessonContent, CodeBlock
-│   ├── quiz/          # QuizQuestion, QuizResult
-│   ├── games/         # CommandBuilder, PluginMatcher, etc.
-│   └── gamification/  # XPBar, LevelBadge, StreakCounter
-├── contexts/          # UserContext, GameContext
-├── hooks/             # useLocalStorage, useXP, useProgress
-├── pages/             # Dashboard, Module, Lesson, Quiz, Game
-├── data/              # types.ts, constants.ts, badges.ts
-└── utils/             # helpers, formatters
+│   ├── quiz/          # QuizQuestion, QuizResult, AnswerOption
+│   ├── games/         # CommandBuilder, PluginMatcher, BuildPipeline, StoreReviewer, ArchitecturePlanner
+│   └── gamification/  # XPBar, LevelBadge, StreakCounter, BadgeCard, LevelUpPopup, AchievementPopup
+├── contexts/          # UserContext
+├── hooks/             # useLocalStorage, useXP, useProgress, useStreak, useBadges, useTranslatedContent
+├── pages/             # Dashboard, Module, Lesson, Quiz, Game, NotFound
+├── data/              # types.ts, constants.ts, badges.ts, lessons.ts, quizzes.ts, games.ts
+├── i18n/
+│   ├── index.ts       # Configuración i18next
+│   └── locales/
+│       ├── es/        # Español (default)
+│       ├── en/        # English
+│       └── pt/        # Português
+├── utils/             # helpers, formatters, module-utils
+└── styles/            # globals.css
 ```
+
+## Módulos Implementados
+
+| Módulo | Tema | Lecciones | Mini-juego | XP Req |
+|--------|------|-----------|------------|--------|
+| 1 | Setup + Fundamentos | 5 | Command Builder | 0 |
+| 2 | Plugins Core | 6 | Plugin Matcher | 100 |
+| 3 | Build Processes | 5 | Build Pipeline | 300 |
+| 4 | App Store Prep | 4 | Store Reviewer | 450 |
+| 5 | Arquitectura Avanzada | 6 | Architecture Planner | 600 |
+
+**Total:** 26 lecciones, 5 quizzes, 5 mini-juegos
 
 ## Reglas
 
@@ -45,6 +67,7 @@ src/
 3. **Componentes funcionales** con hooks
 4. **localStorage** para persistencia
 5. **Tests** para lógica de gamificación
+6. **i18n** - Todas las strings deben usar traducciones
 
 ## Comandos
 
@@ -53,6 +76,7 @@ npm run dev          # Desarrollo
 npm run build        # Producción
 npm test             # Tests
 npm run lint         # ESLint
+npm run typecheck    # TypeScript check
 ```
 
 ## Sistema de Gamificación
@@ -71,20 +95,29 @@ npm run lint         # ESLint
 4. Store Publisher (601-1000)
 5. Capacitor Expert (1001+)
 
+### Badges (14 total)
+- first-lesson, quiz-master, streak-3, perfectionist
+- plugin-explorer, speed-learner, completionist, night-owl
+- early-bird, module-master, game-champion, dedicated-learner
+- bug-hunter, community-contributor
+
+## Tipos de Mini-juegos
+
+| GameType | Componente | Descripción |
+|----------|------------|-------------|
+| command-builder | CommandBuilder | Drag-drop partes de comandos CLI |
+| plugin-matcher | PluginMatcher | Conectar casos de uso con plugins |
+| build-pipeline | BuildPipeline | Ordenar pasos del build process |
+| store-reviewer | StoreReviewer | Identificar errores de app store |
+| architecture-planner | ArchitecturePlanner | Clasificar componentes en capas |
+
+## CI/CD
+
+- **GitHub Actions:** lint, typecheck, test, build
+- **Vercel:** Preview deploys en PRs, Production en main
+- **Codecov:** Cobertura de tests
+
 ## Repos Relacionados
 
 - `capacitor-learning-content` - Lecciones, quizzes, datos de juegos
 - `capacitor-learning-docs` - Sistema de agentes, guías
-
-## Agentes
-
-Para tareas complejas, consultar el sistema de agentes en `capacitor-learning-docs/agents/`.
-
-| Tarea | Agente |
-|-------|--------|
-| UI components | frontend-developer |
-| Mini-juegos | mini-games-developer |
-| XP/Niveles | xp-levels-specialist |
-| Animaciones | animation-specialist |
-| Tests | tester |
-| Review | code-reviewer |

--- a/README.md
+++ b/README.md
@@ -102,12 +102,15 @@ npm run typecheck
 
 ## Módulos Educativos
 
-| Módulo | Tema | Mini-juego |
-|--------|------|------------|
-| 1 | Setup + Fundamentos Capacitor | Command Builder |
-| 2 | Plugins Core + Web-to-Native Bridge | Plugin Matcher |
-| 3 | Desarrollo + Build Processes | Build Pipeline |
-| 4 | Testing + App Store Preparation | Store Reviewer |
+| Módulo | Tema | Lecciones | Mini-juego |
+|--------|------|-----------|------------|
+| 1 | Setup + Fundamentos Capacitor | 5 | Command Builder |
+| 2 | Plugins Core + Web-to-Native Bridge | 6 | Plugin Matcher |
+| 3 | Desarrollo + Build Processes | 5 | Build Pipeline |
+| 4 | Testing + App Store Preparation | 4 | Store Reviewer |
+| 5 | Arquitectura Avanzada | 6 | Architecture Planner |
+
+**Total:** 26 lecciones interactivas, 5 quizzes de evaluación, 5 mini-juegos
 
 ## Sistema de Gamificación
 


### PR DESCRIPTION
## Summary
- Updates CLAUDE.md with current project state
- Adds Module 5 to README.md modules table

### CLAUDE.md Changes
- Fixed testing framework (Vitest, not Jest)
- Added i18n info (react-i18next ES/EN/PT)
- Updated folder structure with all components
- Added modules table with lesson counts and XP requirements
- Added mini-games reference table
- Added badges list
- Added CI/CD section
- Added live URL

### README.md Changes
- Added Module 5: Arquitectura Avanzada (6 lessons, Architecture Planner game)
- Added lesson count column to modules table
- Added totals summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)