### PR TITLE
fix: add missing icons for modules 7-12

### DIFF
--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -14,18 +14,31 @@ import {
   GraduationCap,
   Brain,
   Gamepad2,
+  Database,
+  Palette,
+  GitBranch,
+  DollarSign,
+  Link,
+  Cpu,
   type LucideIcon,
 } from 'lucide-react'
 
 // Map icon names to Lucide components
 const iconMap: Record<string, LucideIcon> = {
-  // Modules
+  // Modules 1-6
   rocket: Rocket,
   plug: Plug,
   hammer: Hammer,
   store: Store,
   layers: Layers,
   shield: Shield,
+  // Modules 7-12
+  database: Database,
+  palette: Palette,
+  'git-branch': GitBranch,
+  'dollar-sign': DollarSign,
+  link: Link,
+  cpu: Cpu,
   // Levels
   sprout: Sprout,
   crown: Crown,


### PR DESCRIPTION
## Problem
Modules 7-12 were showing icon names as text instead of actual icons in the sidebar.

## Solution
Added missing Lucide icons to the Icon component:
- `database` - Module 7 (Offline-First & Data Sync)
- `palette` - Module 8 (UI/UX Nativo)
- `git-branch` - Module 9 (CI/CD & Testing)
- `dollar-sign` - Module 10 (Monetización)
- `link` - Module 11 (Deep Linking)
- `cpu` - Module 12 (Hardware APIs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)